### PR TITLE
Updated External Links with rel="noopener"

### DIFF
--- a/sitewide/templates/sitewide/base.html
+++ b/sitewide/templates/sitewide/base.html
@@ -61,13 +61,13 @@
                         </li>
                     {% endif %}
                     <li class="nav-item">
-                        <a class="nav-link" href="https://github.com/zappycode/zappycode-django" target="_blank">Code</a>
+                        <a class="nav-link" href="https://github.com/zappycode/zappycode-django" rel="noopener" target="_blank">Code</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'money:home' %}">Money</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="https://plausible.io/zappycode.com" target="_blank">Analytics</a>
+                        <a class="nav-link" href="https://plausible.io/zappycode.com" rel="noopener" target="_blank">Analytics</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav ml-auto">


### PR DESCRIPTION
Adding this attribute will reduce website vulnerabilities and maybe help performance.

- The other page may run on the same process as your page. If the other page is running a lot of JavaScript, your page's performance may suffer.
- The other page can access your window object with the window.opener property. This may allow the other page to redirect your page to a malicious URL.
